### PR TITLE
Prevent the addition of multiple events to the pagination class

### DIFF
--- a/js/pagination.js
+++ b/js/pagination.js
@@ -154,6 +154,7 @@
             var $target = this.$target,
                 options = this.options,
                 me = this;
+            $target.off('click');
             $target.on('click', '>li>a[data-page]', function (e) {
                 if ($(this).parent().hasClass('disabled') || $(this).parent().hasClass('active')) {
                     return


### PR DESCRIPTION
I found a event register bug.

When another Ajax process done, pagination events was registerd multiple. 